### PR TITLE
Convert query parameters to numbers.

### DIFF
--- a/lib/services.credentials.js
+++ b/lib/services.credentials.js
@@ -127,10 +127,10 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
         }
         var options = {};
         if(req.query.limit > 0) {
-          options.limit = req.query.limit;
+          options.limit = Number(req.query.limit);
         }
         if(req.query.offset > 0) {
-          options.skip = req.query.offset;
+          options.skip = Number(req.query.offset);
         }
         if(sortOptions.sort.length > 0) {
           _.assign(options, sortOptions);


### PR DESCRIPTION
This is due to a change in the mongo API: https://jira.mongodb.org/browse/DOCS-6995

Link from another project:
https://github.com/florianholzapfel/express-restify-mongoose/issues/215
